### PR TITLE
Fix: Redirect root to (tabs) route

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,34 +1,5 @@
-import { StyleSheet, Text, View } from "react-native";
+import { Redirect } from "expo-router";
 
 export default function Page() {
-  return (
-    <View style={styles.container}>
-      <View style={styles.main}>
-        <Text style={styles.title}>Hello World</Text>
-        <Text style={styles.subtitle}>This is the first page of your app.</Text>
-      </View>
-    </View>
-  );
+  return <Redirect href="/(tabs)" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: "center",
-    padding: 24,
-  },
-  main: {
-    flex: 1,
-    justifyContent: "center",
-    maxWidth: 960,
-    marginHorizontal: "auto",
-  },
-  title: {
-    fontSize: 64,
-    fontWeight: "bold",
-  },
-  subtitle: {
-    fontSize: 36,
-    color: "#38434D",
-  },
-});


### PR DESCRIPTION
The app was incorrectly displaying a generic welcome screen (Hello World) instead of the list of waterfalls.

This was because the `app/index.tsx` was rendering a static page instead of redirecting to the main content.

This commit modifies `app/index.tsx` to use the `Redirect` component from `expo-router` to navigate directly to the `/(tabs)` route, which displays the waterfall list.