### PR TITLE
Fix: Correct app entry point to show waterfall list

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StyleSheet, FlatList, SafeAreaView } from 'react-native';
 import WaterfallCard from '@/components/WaterfallCard';
-import EditScreenInfo from '@/components/EditScreenInfo';
 import { Text, View } from '@/components/Themed';
 import waterfallsData from '@/assets/waterfalls.json';
 import { Waterfall } from '@/types/waterfall';
@@ -12,10 +11,6 @@ export default function TabOneScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        {/* Static header from `main` branch */}
-        <Text style={styles.title}>Hamilton Falls</Text>
-        <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
-        <EditScreenInfo path="app/(tabs)/index.tsx" />
 
         {/* Dynamic list from `feat/waterfall-list` branch */}
         <FlatList


### PR DESCRIPTION
The app was incorrectly displaying a "Welcome to Expo" screen instead of the list of waterfalls.

This was caused by:
- The `EditScreenInfo` component being rendered in `app/(tabs)/index.tsx`.
- A static header component also present in `app/(tabs)/index.tsx`.

This commit removes these unnecessary components from `app/(tabs)/index.tsx` so that the `FlatList` of waterfalls is displayed as the initial content.

The root layout already directs the initial route to `(tabs)`, and `app/index.tsx` correctly redirects to `/(tabs)` as a fallback.